### PR TITLE
MediaPlayerDevice is deprecated

### DIFF
--- a/custom_components/xiaomi_gateway_radio/README.md
+++ b/custom_components/xiaomi_gateway_radio/README.md
@@ -1,0 +1,22 @@
+# xiaomi_miio_gateway
+Home Assistant Xiaomi Gateway Radio
+
+This is a custom component to play/stop the Network radio in a Xiaomi Gateway
+
+this plays the last played station on the gateway
+
+follow this to get custom radios in the gateway ->
+http://ximiraga.ru
+
+
+configuration.yaml example
+```yaml
+media_player:
+  - platform: xiaomi_gateway_radio
+    host: <ip of gateway>
+    token: <gateway token>
+```
+
+token is obtained the same way as explained here ->
+https://www.home-assistant.io/components/vacuum.xiaomi_miio/#retrieving-the-access-token
+

--- a/custom_components/xiaomi_gateway_radio/__init__.py
+++ b/custom_components/xiaomi_gateway_radio/__init__.py
@@ -1,0 +1,1 @@
+"""Component init"""

--- a/custom_components/xiaomi_gateway_radio/manifest.json
+++ b/custom_components/xiaomi_gateway_radio/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "xiaomi_gateway_radio",
+  "name": "Xiaomi Gateway Radio",
+  "documentation": "https://github.com/h4v1nfun/xiaomi_miio_gateway",
+  "dependencies": [],
+  "codeowners": [
+    "@h4v1nfun"
+  ],
+  "requirements": []
+}

--- a/custom_components/xiaomi_gateway_radio/media_player.py
+++ b/custom_components/xiaomi_gateway_radio/media_player.py
@@ -8,7 +8,7 @@ import asyncio
 from functools import partial
 
 import homeassistant.helpers.config_validation as cv 
-from homeassistant.components.media_player import (MediaPlayerDevice, PLATFORM_SCHEMA)
+from homeassistant.components.media_player import (MediaPlayerEntity, PLATFORM_SCHEMA)
 from homeassistant.components.media_player.const import (SUPPORT_TURN_ON, SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_VOLUME_STEP, SUPPORT_VOLUME_SET, SUPPORT_NEXT_TRACK) 
 from homeassistant.const import (CONF_HOST, CONF_NAME, CONF_TOKEN, STATE_OFF, STATE_ON)
 
@@ -63,7 +63,7 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     hass.data[DATA_KEY][host] = device
     async_add_devices([device], update_before_add=True)
 
-class XiaomiGateway(MediaPlayerDevice):
+class XiaomiGateway(MediaPlayerEntity):
     """Represent the Xiaomi Gateway for Home Assistant."""
 
     def __init__(self, device, config, device_info):


### PR DESCRIPTION
As MediaPlayerDevice is deprecated, it should be replaced by MediaPlayerEntity
Also Home Assistant and HACS needs some additional files