### PR TITLE
Adding compatibility with HA 2023.6 (Python 3.11)

### DIFF
--- a/custom_components/xiaomi_gateway_radio/media_player.py
+++ b/custom_components/xiaomi_gateway_radio/media_player.py
@@ -35,8 +35,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
 })
 
-@asyncio.coroutine
-def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     """Set up the Xiaomi Gateway miio platform."""
     from miio import Device, DeviceException
     if DATA_KEY not in hass.data:


### PR DESCRIPTION
After updating to 2023.6.0, an error occurs due to the absence of async.coroutine
This is a quick fix.